### PR TITLE
Change id type of Questions

### DIFF
--- a/question-service/package-lock.json
+++ b/question-service/package-lock.json
@@ -12,7 +12,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
-        "mongoose": "^8.6.3"
+        "mongoose": "^8.6.3",
+        "mongoose-sequence": "^6.0.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -287,6 +288,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -922,6 +929,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1084,6 +1097,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose-sequence": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mongoose-sequence/-/mongoose-sequence-6.0.1.tgz",
+      "integrity": "sha512-uXnLCW9pu2V49Xw8BmdXdeRugd2mv+ntu3nT2Bbm33pNRmmvHE2GKA+8BASKoQt960McLX4VL78wkb492f6MoQ==",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "async": "^3.2.5",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "mongoose": ">=5"
       }
     },
     "node_modules/mongoose/node_modules/ms": {

--- a/question-service/package.json
+++ b/question-service/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
-    "mongoose": "^8.6.3"
+    "mongoose": "^8.6.3",
+    "mongoose-sequence": "^6.0.1"
   }
 }

--- a/question-service/src/models/questionModel.ts
+++ b/question-service/src/models/questionModel.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document } from "mongoose"
+const AutoIncrement = require('mongoose-sequence')(mongoose);
 
 interface IQuestion extends Document {
     title: string
@@ -9,6 +10,9 @@ interface IQuestion extends Document {
 
 const questionSchema = new mongoose.Schema(
     {
+        _id: {
+            type: Number,
+        },
         title: {
             type: String,
             required: true,
@@ -29,7 +33,9 @@ const questionSchema = new mongoose.Schema(
     },
     {
         timestamps: true,
+        id_: false,
     }
 )
 
+questionSchema.plugin(AutoIncrement);
 export const Question = mongoose.model<IQuestion>('Question', questionSchema)


### PR DESCRIPTION
Changed Question to have a `id` parameter that auto-increments

potential problem: once you delete a question, that `id` will never come back. E.g. if you delete Question of `id` = 2, then the list of Questions will have id `1,3,4,...`. But @brein62 says its ok!