### PR TITLE
Add title to title bar for all pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>PeerPrep</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom"
-import MainPage from "./pages/MainPage"
 import LoginPage from "./pages/user-service/LoginPage"
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
 import EditQuestionPage from "./pages/question-service/EditQuestionPage";

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -1,10 +1,17 @@
+import MainContainer from "@/components/common/MainContainer"
+import PageTitle from "@/components/common/PageTitle";
+
 /**
  * The error page is displayed when trying to access an invalid URL.
  */
 export default function ErrorPage() {
+
+  document.title="Error | PeerPrep"
+
   return (
-    <>
-      The page you were trying to visit is invalid. <a href="/">Return to home page</a>
-    </>
+    <MainContainer>
+      <PageTitle>Something went wrong :(</PageTitle>
+      <strong>Error: </strong>The page you were trying to visit is invalid. <a href="/">Return to home page</a>
+    </MainContainer>
   );
 }

--- a/frontend/src/pages/SamplePage.tsx
+++ b/frontend/src/pages/SamplePage.tsx
@@ -6,9 +6,11 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 
 /**
- * @returns Sample main page.
+ * Returns a sample main page. The main page is now the `ListQuestionPage` or `LoginPage`.
+ * 
+ * @returns Sample main page. Currently not used.
  */
-export default function MainPage() {
+export default function SamplePage() {
   const { auth, logout } = useAuth();
   const [count, setCount] = useState(0)
   const navigate = useNavigate();

--- a/frontend/src/pages/question-service/AddQuestionPage.tsx
+++ b/frontend/src/pages/question-service/AddQuestionPage.tsx
@@ -6,6 +6,7 @@ import EditQuestionForm from "@/components/question-service/edit-question-page/E
  * Page for admins to add questions.
  */
 export default function AddQuestionPage() {
+  document.title="Add New Question | PeerPrep";
 
   return (
     <>

--- a/frontend/src/pages/question-service/EditQuestionPage.tsx
+++ b/frontend/src/pages/question-service/EditQuestionPage.tsx
@@ -8,6 +8,8 @@ export default function EditQuestionPage() {
 
   const id = params.id;
 
+  document.title = `Edit Question #${id} | PeerPrep`;
+
   return (
     <>
       <PageHeader />

--- a/frontend/src/pages/question-service/ListQuestionPage.tsx
+++ b/frontend/src/pages/question-service/ListQuestionPage.tsx
@@ -20,6 +20,8 @@ export default function ListQuestionPage() {
   const [ search, setSearch ] = useState("");
   const { auth } = useAuth();
 
+  document.title = `Question List | PeerPrep`;
+
   const updateQuestionTable = () => {
     fetchQuestions().then(questionList => {
       setQuestions(questionList);

--- a/frontend/src/pages/question-service/ViewQuestionPage.tsx
+++ b/frontend/src/pages/question-service/ViewQuestionPage.tsx
@@ -10,6 +10,8 @@ export default function ViewQuestionPage() {
   const id = params.id as string;
   const [question, setQuestion] = useState<Question | null>(null);
 
+  document.title = `View Question #${id} | PeerPrep`;
+
   useEffect(() => {
     const loadQuestion = async () => {
       if (id) {

--- a/frontend/src/pages/user-service/AccountSettingsPage.tsx
+++ b/frontend/src/pages/user-service/AccountSettingsPage.tsx
@@ -1,4 +1,6 @@
-export default function SignupPage() {
+export default function AccountSettingsPage() {
+  document.title="Account Settings | PeerPrep";
+
   return (
     <>
       Account settings page

--- a/frontend/src/pages/user-service/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/user-service/ForgotPasswordPage.tsx
@@ -1,4 +1,6 @@
 export default function ForgotPasswordPage() {
+  document.title="Forgot Password | PeerPrep";
+
   return (
     <>
       Forgot password page

--- a/frontend/src/pages/user-service/LoginPage.tsx
+++ b/frontend/src/pages/user-service/LoginPage.tsx
@@ -11,6 +11,8 @@ export default function LoginPage() {
     navigate('/');
   }
 
+  document.title="Login | PeerPrep";
+
   return (
     <>
       <p>

--- a/frontend/src/pages/user-service/SignupPage.tsx
+++ b/frontend/src/pages/user-service/SignupPage.tsx
@@ -1,4 +1,6 @@
 export default function SignupPage() {
+  document.title="Sign Up | PeerPrep";
+
   return (
     <>
       Signup page


### PR DESCRIPTION
Fixes #29.

![image](https://github.com/user-attachments/assets/678e019c-a0b0-4f6c-91dc-4e13958571eb)

Set all page titles to describe the page name.