### PR TITLE
[Question Service] Allow deselection in topic selector

### DIFF
--- a/frontend/src/components/question-service/edit-question-page/QuestionTopicsField.tsx
+++ b/frontend/src/components/question-service/edit-question-page/QuestionTopicsField.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useToast } from "@/hooks/use-toast";
 import {
   Command,
   CommandEmpty,
@@ -30,19 +29,15 @@ export default function QuestionTopicsField({
     fetchTopics().then((topics) => setTopics(topics));
   }, []);
 
-  const { toast } = useToast();
-
   const removeTopic = (removed: string) => {
     setValue(value.filter((topic) => topic !== removed));
   };
 
-  const addTopic = (newTopic: string) => {
+  const toggleTopic = (newTopic: string) => {
     if (!value.includes(newTopic)) {
       setValue([...value, newTopic]);
     } else {
-      toast({
-        description: "Topic not added as it already exists.",
-      });
+      setValue(value.filter(topic => topic !== newTopic));
     }
   };
 
@@ -82,7 +77,7 @@ export default function QuestionTopicsField({
             align="start"
           >
             <Command>
-              <CommandInput placeholder="search..." />
+              <CommandInput placeholder="Search..." />
               <CommandList>
                 <CommandEmpty>No results found.</CommandEmpty>
                 <CommandGroup heading="Topics">
@@ -90,7 +85,7 @@ export default function QuestionTopicsField({
                     {topics.map((topic) => (
                       <CommandItem
                         key={topic}
-                        onSelect={() => addTopic(topic)}
+                        onSelect={() => toggleTopic(topic)}
                         className="cursor-pointer rounded-md px-2 py-1 text-sm hover:bg-gray-100"
                       >
                         <span className={cn(


### PR DESCRIPTION
Currently, deselecting the topic selector leads to an error toast message. This simple change allows for deselection in the topic selector.

![ezgif-3-1d00b032ab](https://github.com/user-attachments/assets/a0eae6da-d950-4ed3-898e-648065c0ab8c)
