### PR TITLE
Add broad categories per project document

### DIFF
--- a/question-service/src/models/questionTopics.ts
+++ b/question-service/src/models/questionTopics.ts
@@ -33,6 +33,10 @@ const QUESTION_TOPICS = [
     "Matrix",
     "Graph Traversal",
     "Topological Sort",
+    "Data Structures",
+    "Algorithms",
+    "Databases",
+    "Brainteaser"
 ];
   
 export default QUESTION_TOPICS


### PR DESCRIPTION
The project document has broad categories for some problems (Data Structures, Algorithms, Databases, Brainteaser) in addition to the LeetCode topics for each of the problems.

This PR just adds all broad categories present in the project document.

For example:
![image](https://github.com/user-attachments/assets/676a54d1-7fb9-448d-a520-9c79ec0a80c4)
