### PR TITLE
Revert to primitive matching service

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,11 @@ import AccountSettingsPage from "./pages/user-service/AccountSettingsPage";
 import ErrorPage from "./pages/ErrorPage";
 import AddQuestionPage from "./pages/question-service/AddQuestionPage";
 import { Toaster } from "./components/ui/toaster";
+import StartMatchingPage from "./pages/matching-service/StartMatchingPage";
+import WaitForMatchingPage from "./pages/matching-service/WaitForMatchingPage";
+import MatchingFailedPage from "./pages/matching-service/MatchingFailedPage";
+import GetReadyPage from "./pages/matching-service/GetReadyPage";
+import CollaborationPage from "./pages/collaboration-service/CollaborationPage";
 
 /**
  * A wrapper around routes that should only be accessed by logged-in users.
@@ -140,6 +145,35 @@ function App() {
               nonAdminRoute={ <Navigate to="/questions" /> }
             />
           } />
+          <Route path="/matching/start" element={
+            <PrivateRoute>
+              <StartMatchingPage />
+            </PrivateRoute>
+          } />
+          <Route path="/matching/wait" element={
+            <PrivateRoute>
+              <WaitForMatchingPage />
+            </PrivateRoute>
+          }
+          />
+          <Route path="/matching/failed" element={
+            <PrivateRoute>
+              <MatchingFailedPage />
+            </PrivateRoute>
+          }
+          />
+          <Route path="/matching/get_ready" element={
+            <PrivateRoute>
+              <GetReadyPage />
+            </PrivateRoute>
+          }
+          />
+          <Route path="/collaboration" element={
+            <PrivateRoute>
+              <CollaborationPage />
+            </PrivateRoute>
+          }
+          />
           <Route path="*" Component={ ErrorPage } />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/api/matching-service/MatchingService.ts
+++ b/frontend/src/api/matching-service/MatchingService.ts
@@ -1,0 +1,139 @@
+import axios from "axios";
+import { SelectedDifficultyData } from "@/components/matching-service/DifficultySelectionBox";
+
+const MATCHING_SERVICE_URL = "http://localhost:5000/";
+const MATCHING_BASE_URL = "/matching";
+const START_MATCHING_URL = "/start";
+const CHECK_MATCHING_STATE_URL = "/check_state";
+const CANCEL_MATCHING_URL = "/cancel";
+const CONFIRM_READY_URL = "/ready/yes"
+const CONFIRM_NOT_READY_URL = "/ready/no"
+const CHECK_PEER_READY_STATE_URL = "/ready/check_state"
+
+const api = axios.create({baseURL : MATCHING_SERVICE_URL})
+
+let previousStartMatchingData : any = null;
+
+/**
+ * An async function for sending a start matching request to the backend.
+ * 
+ * @param token The current user's token.
+ * @param difficulties The difficulties selected by the user for matching.
+ * @param topics The topics selected by the user for matching.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server
+ */
+async function sendStartMatchingRequest(token : string, difficulties : SelectedDifficultyData, topics : string[]) {
+  const requestBody = {
+    userToken : token,
+    difficulties : difficulties,
+    topics : topics
+  }
+
+  previousStartMatchingData = requestBody;
+
+  return await api.post(MATCHING_BASE_URL + START_MATCHING_URL, requestBody).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    return {status : error.status, message : error.response.data.message}
+  })
+}
+
+/**
+ * An async function for resending the previous start matching request to the backend.
+ * This function will use the `difficulties` and `topics` data from the previous `sendStartMatchingRequest` call, so make sure that you have called `sendStartMatchingRequest` at least for one time before calling this function.
+ * 
+ * @param token The current user's token.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server.
+ */
+async function retryPreviousMatching(token : string) {
+  if(previousStartMatchingData === null) {
+    throw new Error("[retryMatching] previousStartMatchingData is null");
+  }
+
+  return await api.post(MATCHING_BASE_URL + START_MATCHING_URL, {...previousStartMatchingData, userToken : token}).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    return {status : error.status, message : error.response.data.message}
+  })
+}
+
+/**
+ * An async function for sending a check matching state request to the backend.
+ * You should call this function intermittently for multiple times when waiting for matching in order to get the latest matching state.
+ * 
+ * @param token The current user's token.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server.
+ */
+async function sendCheckMatchingStateRequest(token : string) {
+  const requestBody = {
+    userToken : token
+  }
+  return await api.post(MATCHING_BASE_URL + CHECK_MATCHING_STATE_URL, requestBody).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    if(error.code === "ERR_NETWORK") {
+      return {status : error.status, message : "ERR_NETWORK"}
+    }
+    return {status : error.status, message : error.response.data.message}
+  });
+}
+
+/**
+ * An async function for sending a cancel matching request to the backend.
+ * The request is for notifying the backend that the frontend stops using the matching service (for example: user decided to cancel matching, user left the waiting matching page, etc.)
+ * 
+ * @param token The current user's token.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server.
+ */
+async function sendCancelMatchingRequest(token : string) {
+  const requestBody = {
+    userToken : token
+  }
+  return await api.post(MATCHING_BASE_URL + CANCEL_MATCHING_URL, requestBody).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    return {status : error.status, message : error.response.data.message}
+  })
+}
+
+/**
+ * An async function for updating the ready state of the current user to the backend.
+ * 
+ * @param token The current user's token.
+ * @param isReady `true` if the user is confirmed ready, and `false` if the user failed to get ready in time.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server.
+ */
+async function sendUpdateReadyStateRequest(token : string, isReady : boolean) {
+  const requestBody = {
+    userToken : token
+  }
+  const url = isReady ? CONFIRM_READY_URL : CONFIRM_NOT_READY_URL;
+  return await api.post(MATCHING_BASE_URL + url, requestBody).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    return {status : error.status, message : error.response.data.message}
+  })
+}
+
+/**
+ * An async function for sending a check peer ready state request to the backend.
+ * You should call this function intermittently for multiple times when waiting for the peer to get ready in order to get the latest state.
+ * 
+ * @param token The current user's token.
+ * @returns An object containing the HTTP status code of the request and the message from the backend server.
+ */
+async function sendCheckPeerReadyStateRequest(token : string) {
+  const requestBody = {
+    userToken : token
+  }
+  return await api.post(MATCHING_BASE_URL + CHECK_PEER_READY_STATE_URL, requestBody).then(response => {
+    return {status : response.status, message : response.data.message}
+  }).catch(error => {
+    if(error.code === "ERR_NETWORK") {
+      return {status : error.status, message : "ERR_NETWORK"}
+    }
+    return {status : error.status, message : error.response.data.message}
+  });
+}
+
+export { sendStartMatchingRequest, sendCheckMatchingStateRequest, sendCancelMatchingRequest, sendUpdateReadyStateRequest, sendCheckPeerReadyStateRequest, retryPreviousMatching };

--- a/frontend/src/components/matching-service/DifficultySelectionBox.tsx
+++ b/frontend/src/components/matching-service/DifficultySelectionBox.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import Difficulty, { TDifficulty } from "../question-service/Difficulty";
+import { Checkbox } from "../ui/checkbox";
+
+export type SelectedDifficultyData = {[difficulty in TDifficulty] : boolean};
+export const DEFAULT_SELECTED_DIFFICULTY_DATA = {easy: false, medium: false, hard: false};
+
+export default function DifficultySelectionBox({onChange} : {onChange : (newValue : SelectedDifficultyData) => void}) {
+  
+  const [displayDropdown, setDisplayDropdown] = useState(false);
+  const [selectedDifficultyData, setSelectedDifficultyData] = useState<SelectedDifficultyData>(DEFAULT_SELECTED_DIFFICULTY_DATA);
+  const availableDifficulties : TDifficulty[] = ["easy", "medium", "hard"];
+
+  const setDifficultySelected = (difficulty : TDifficulty, isSelected : boolean) => {
+    const newData = {...selectedDifficultyData, [difficulty] : isSelected}
+    setSelectedDifficultyData(newData);
+    onChange(newData);
+  }
+
+  const isDifficultySelected = (difficulty : TDifficulty) => selectedDifficultyData[difficulty];
+
+  const inverseDifficultySelection = (difficulty : TDifficulty) => {
+    setDifficultySelected(difficulty, !isDifficultySelected(difficulty))
+  }
+
+  return(
+    <>
+      <div className="flex flex-col min-w-[115px]" onMouseEnter={() => setDisplayDropdown(true)} onMouseLeave={() => setDisplayDropdown(false)}>
+        <div>Difficulties</div>
+        <div
+          className="flex flex-row space-x-1 p-1 h-9 w-full rounded-md border border-input"
+        >
+          {availableDifficulties.map(difficulty => isDifficultySelected(difficulty) && (<Difficulty key={difficulty} type={difficulty as TDifficulty}/>))}
+        </div>
+        {displayDropdown && (
+          <div className="flex flex-col space-y-1 p-2 bg-black rounded-md bg-opacity-10">
+            {
+              availableDifficulties.map(difficulty=>
+                <div key={difficulty} className="flex flex-row space-x-1 items-center" onClick={()=>inverseDifficultySelection(difficulty)}>
+                  {isDifficultySelected(difficulty)  && (<Checkbox checked={true} onClick={()=>inverseDifficultySelection(difficulty)}/>)}
+                  <Difficulty type={difficulty}/>
+                </div>
+              )
+            }
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/matching-service/SpinningCircle.tsx
+++ b/frontend/src/components/matching-service/SpinningCircle.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+export default function SpinningCircle({children} : {children? : ReactNode | undefined}) {
+  return(
+    <>
+      <div className="flex justify-center items-center relative w-20 h-20">
+        <div className="absolute inset-0 animate-spin rounded-full border-4 border-t-transparent border-black" />
+        {children}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import PageTitle from "../common/PageTitle";
+import QuestionTopicsField from "../question-service/edit-question-page/QuestionTopicsField";
+import DifficultySelectionBox, { DEFAULT_SELECTED_DIFFICULTY_DATA, SelectedDifficultyData } from "./DifficultySelectionBox";
+import { Button } from "../ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { sendStartMatchingRequest } from "@/api/matching-service/MatchingService";
+import { useNavigate } from "react-router-dom";
+import { DisplayedMessage, DisplayedMessageContainer, DisplayedMessageTypes } from "../common/DisplayedMessage";
+
+export default function StartMatchingForm() {
+
+  const { auth } = useAuth();
+  const navigate = useNavigate();
+
+  const [questionTopics, setQuestionTopics] = useState<string[]>([]);
+  const [selectedDifficultyData, setSelectedDifficultyData] = useState<SelectedDifficultyData>(DEFAULT_SELECTED_DIFFICULTY_DATA);
+  const [displayedMessage, setDisplayedMessage] = useState<DisplayedMessage | null>(null);
+
+  const startMatching = () : void => {
+    if(!selectedDifficultyData.easy && !selectedDifficultyData.medium && !selectedDifficultyData.hard) {
+      displayError("You must select at least one difficulty.");
+      return;
+    }
+    if(questionTopics.length === 0) {
+      displayError("You must select at least one topic.");
+      return;
+    }
+    sendStartMatchingRequest(auth.token, selectedDifficultyData, questionTopics).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          const difficultiesStr = Object.entries(selectedDifficultyData).filter(val => val[1]).map(val => val[0]).join(", ");
+          const topicsStr = questionTopics.join(", ");
+          navigate(`../matching/wait?difficulties=${difficultiesStr}&topics=${topicsStr}`);
+        }
+        else {
+          displayError("An error has occured: \n" + response.message);
+        }
+      }
+    )
+  }
+
+  const displayError = (message : string) => {
+    setDisplayedMessage({message : message, type : DisplayedMessageTypes.Error});
+  }
+  
+  return(
+  <>
+    <form onSubmit={evt => {evt.preventDefault();} } className="h-full">
+      <PageTitle>Practice an Interview</PageTitle>
+      <p>What question would you like to practice today?</p>
+      <div className="flex flex-row mt-5">
+        <DifficultySelectionBox onChange={setSelectedDifficultyData}/>
+        <div className="ml-5 mr-5"/>
+        <QuestionTopicsField value={questionTopics} setValue={setQuestionTopics}></QuestionTopicsField>
+      </div>
+      <div className="flex justify-center mt-20">
+        <Button className="btnblack" onClick={startMatching}>Find a match</Button>
+      </div>
+      <DisplayedMessageContainer displayedMessage={displayedMessage}/>
+    </form>
+  </>
+  )
+}

--- a/frontend/src/pages/collaboration-service/CollaborationPage.tsx
+++ b/frontend/src/pages/collaboration-service/CollaborationPage.tsx
@@ -1,0 +1,10 @@
+import { Link } from "react-router-dom";
+
+export default function collaborationPage() {
+    return (
+    <>
+      <div>You have successfully matched someone. This is the collaboration page that is still TODO.</div>
+      <Link to="../matching/start">Back to matching</Link>
+    </>
+    );
+}

--- a/frontend/src/pages/matching-service/GetReadyPage.tsx
+++ b/frontend/src/pages/matching-service/GetReadyPage.tsx
@@ -1,0 +1,176 @@
+import { retryPreviousMatching, sendCheckPeerReadyStateRequest, sendUpdateReadyStateRequest } from "@/api/matching-service/MatchingService";
+import { DisplayedMessage, DisplayedMessageContainer, DisplayedMessageTypes } from "@/components/common/DisplayedMessage";
+import MainContainer from "@/components/common/MainContainer";
+import PageHeader from "@/components/common/PageHeader";
+import PageTitle from "@/components/common/PageTitle";
+import SpinningCircle from "@/components/matching-service/SpinningCircle";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+const GET_READY_MAXIMUM_WAIT_TIME = 5; // in seconds
+const CHECK_PEER_READY_STATE_INTERVAL = 1000; // in milliseconds
+const MAXIMUM_CHECK_PEER_READY_STATE_NETWORK_ERROR_COUNT = 2;
+
+export default function GetReadyPage() {
+    
+  const getReadyTimerIntervalID = useRef<number | null>(null);
+  const [ getReadyTimer, setGetReadyTimer ] = useState(GET_READY_MAXIMUM_WAIT_TIME);
+  const pathname = location.pathname;
+  const { auth } = useAuth();
+  const navigate = useNavigate();
+  const checkPeerReadyStateIntervalID = useRef<number | null>(null);
+  const checkPeerReadyStateNetworkErrorCount = useRef(0);
+  const [ isReady, setIsReady ] = useState(false);
+  const [displayedMessage, setDisplayedMessage] = useState<DisplayedMessage | null>(null);
+
+  const [parameters] = useSearchParams();
+  const difficultiesStr = parameters.get("difficulties");
+  const topicsStr = parameters.get("topics");
+
+  const onNavigatingAway = () => {
+    console.log("on navigating away");
+    if(checkPeerReadyStateIntervalID.current !== null) {
+      window.clearInterval(checkPeerReadyStateIntervalID.current);
+      checkPeerReadyStateIntervalID.current = null;
+    }
+    if(getReadyTimerIntervalID.current !== null) {
+      window.clearInterval(getReadyTimerIntervalID.current);
+      getReadyTimerIntervalID.current = null;
+    }
+  }
+
+  const notGettingReady = () => {
+    const MESSAGE_NOT_GETTING_READY_IN_TIME = "You failed to get ready in time after successfully matched someone. Please pay more attention while waiting for matching and try matching again.";
+    sendUpdateReadyStateRequest(auth.token, false);
+    onNavigatingAway();
+    navigate(`../matching/failed?message=${MESSAGE_NOT_GETTING_READY_IN_TIME}&difficulties=${difficultiesStr}&topics=${topicsStr}`)
+  }
+
+  const updateEndMatchingTimer = () => {
+    if(location.pathname !== pathname) {
+      onNavigatingAway();
+      return;
+    }
+    if(isReady) {
+      return;
+    }
+    setGetReadyTimer(val => {
+      if(val - 1 == 0) {
+        notGettingReady();
+      }
+      return val - 1;
+    });
+  }
+
+  const checkPeerReadyState = () => {
+    console.log("checking peer ready state");
+    if(location.pathname !== pathname) {
+      onNavigatingAway();
+      return;
+    }
+    sendCheckPeerReadyStateRequest(auth.token).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          if(response.message === "ready") {
+            console.log("the peer is also ready, starting collaboration");
+            onNavigatingAway();
+            navigate(`../collaboration`);
+          }
+          else if(response.message === "not ready") {
+            console.log("the peer is not ready, retry matching");
+            onNavigatingAway();
+            retryMatching();
+          }
+          return;
+        }
+        if(response.message === "ERR_NETWORK") {
+          checkPeerReadyStateNetworkErrorCount.current++;
+          if(checkPeerReadyStateNetworkErrorCount.current >= MAXIMUM_CHECK_PEER_READY_STATE_NETWORK_ERROR_COUNT) {
+            onNavigatingAway();
+            console.log("waiting for getting ready cancelled due to network error");
+            navigate(`../matching/failed?message=Network error, please check your network and try again.&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+          }
+        }
+        else {
+          onNavigatingAway();
+          console.log("waiting for getting ready cancelled due to backend error");
+          navigate(`../matching/failed?message=${response.message}&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+        }
+      }
+    );
+  }
+
+  const displayError = (message : string) => {
+    setDisplayedMessage({message : message, type : DisplayedMessageTypes.Error});
+  }
+
+  const retryMatching = () => {
+    retryPreviousMatching(auth.token).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          navigate(`../matching/wait?peerNotReady=true&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+        }
+        else {
+          displayError("An error has occured: \n" + response.message);
+        }
+      }
+    )
+  }
+  
+  
+  useEffect(() => {
+    if(getReadyTimerIntervalID.current === null) {
+      getReadyTimerIntervalID.current = window.setInterval(updateEndMatchingTimer, 1000);
+    }
+  }, []);
+
+  document.title = "Get Ready | PeerPrep";
+
+  const getReadyButtonOnClick = () => {
+    sendUpdateReadyStateRequest(auth.token, true).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          setIsReady(true);
+          if(getReadyTimerIntervalID.current !== null) {
+            window.clearInterval(getReadyTimerIntervalID.current);
+          }
+          if(checkPeerReadyStateIntervalID.current === null) {
+            checkPeerReadyStateIntervalID.current = window.setInterval(checkPeerReadyState, CHECK_PEER_READY_STATE_INTERVAL);
+          }
+        }
+        else {
+          displayError("An error has occured: \n" + response.message);
+        }
+      }
+    )
+  }
+
+  return (
+  <>
+    <PageHeader />
+    <MainContainer>
+      <div className="flex flex-col space-y-5 justify-center items-center">
+        <PageTitle>Matching success</PageTitle>
+        <div>We have successfully found a match!</div>
+        {!isReady ? (
+          <>
+            <div>Get ready in {GET_READY_MAXIMUM_WAIT_TIME} seconds!</div>
+            <Button className="btngreen" onClick={getReadyButtonOnClick}>Yes, I'm ready! ({getReadyTimer})</Button>
+          </>
+        ) : (
+          <>
+            <div>Waiting for the other user to get ready...</div>
+            <SpinningCircle />
+          </>
+        )}
+        <DisplayedMessageContainer displayedMessage={displayedMessage}/>
+        </div>
+    </MainContainer>
+  </>
+  )
+}

--- a/frontend/src/pages/matching-service/MatchingFailedPage.tsx
+++ b/frontend/src/pages/matching-service/MatchingFailedPage.tsx
@@ -1,0 +1,60 @@
+import { retryPreviousMatching } from "@/api/matching-service/MatchingService";
+import { DisplayedMessage, DisplayedMessageContainer, DisplayedMessageTypes } from "@/components/common/DisplayedMessage";
+import MainContainer from "@/components/common/MainContainer";
+import PageHeader from "@/components/common/PageHeader";
+import PageTitle from "@/components/common/PageTitle";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+export default function MatchingFailedPage() {
+  const [parameters] = useSearchParams();
+  const navigate = useNavigate();
+  const { auth } = useAuth();
+  const [displayedMessage, setDisplayedMessage] = useState<DisplayedMessage | null>(null);
+
+  const message = parameters.get("message");
+  const difficultiesStr = parameters.get("difficulties");
+  const topicsStr = parameters.get("topics");
+
+
+  const retryButtonOnClick = () => {
+    retryPreviousMatching(auth.token).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          navigate(`../matching/wait?difficulties=${difficultiesStr}&topics=${topicsStr}`);
+        }
+        else {
+          displayError("An error has occured: \n" + response.message);
+        }
+      }
+    )
+  }
+
+  const displayError = (message : string) => {
+    setDisplayedMessage({message : message, type : DisplayedMessageTypes.Error});
+  }
+
+  const refineSelectionButtonOnClick = () => {
+    navigate("../matching/start")
+  }
+
+  document.title = "Matching Failed | PeerPrep";
+
+  return (
+  <>
+    <PageHeader />
+    <MainContainer>
+      <div className="flex flex-col space-y-5 justify-center items-center">
+        <PageTitle>Matching Failed</PageTitle>
+        <div>{message}</div>
+        <Button className="btngreen" onClick={retryButtonOnClick}>Try again</Button>
+        <Button className="btnblack" onClick={refineSelectionButtonOnClick}>Refine selection</Button>
+        <DisplayedMessageContainer displayedMessage={displayedMessage}/>
+      </div>
+    </MainContainer>
+  </>
+  )
+}

--- a/frontend/src/pages/matching-service/StartMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/StartMatchingPage.tsx
@@ -1,0 +1,15 @@
+import MainContainer from "@/components/common/MainContainer";
+import PageHeader from "@/components/common/PageHeader";
+import StartMatchingForm from "@/components/matching-service/StartMatchingForm";
+
+export default function StartMatchingPage() {
+  document.title = "Start a match | PeerPrep";
+  return (
+  <>
+    <PageHeader />
+    <MainContainer>
+      <StartMatchingForm />
+    </MainContainer>
+  </>
+  )
+}

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -1,0 +1,125 @@
+import { sendCancelMatchingRequest, sendCheckMatchingStateRequest } from "@/api/matching-service/MatchingService";
+import MainContainer from "@/components/common/MainContainer";
+import PageHeader from "@/components/common/PageHeader";
+import PageTitle from "@/components/common/PageTitle";
+import SpinningCircle from "@/components/matching-service/SpinningCircle";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+const CHECK_MATCHING_STATE_INTERVAL = 1000; // in milliseconds
+const MAXIMUM_MATCHING_DURATION = 60; // in seconds
+const MAXIMUM_CHECK_MATCHING_STATE_NETWORK_ERROR_COUNT = 5;
+
+export default function WaitForMatchingPage() {
+  const [parameters] = useSearchParams();
+  const navigate = useNavigate();
+  const { auth } = useAuth();
+  const checkMatchingStateIntervalID = useRef<number | null>(null);
+  const endMatchingTimerIntervalID = useRef<number | null>(null);
+  const checkMatchingStateNetworkErrorCount = useRef(0);
+  const [endMatchingTimer, setEndMatchingTimer] = useState(MAXIMUM_MATCHING_DURATION);
+  const pathname = location.pathname;
+
+  const difficultiesStr = parameters.get("difficulties");
+  const topicsStr = parameters.get("topics");
+  const peerNotReady = parameters.get("peerNotReady");
+
+  const checkMatchingState = () => {
+    console.log("checking matching state");
+    if(location.pathname !== pathname) {
+      cancelMatching();
+      console.log("matching cancelled due to leaving page");
+      return;
+    }
+    sendCheckMatchingStateRequest(auth.token).then(
+      response => {
+        const isSuccess = response.status === 200;
+        if(isSuccess) {
+          if(response.message === "match found") {
+            console.log("match found!");
+            cancelMatching(false);
+            navigate(`../matching/get_ready?difficulties=${difficultiesStr}&topics=${topicsStr}`);
+          }
+          return;
+        }
+        if(response.message === "ERR_NETWORK") {
+          checkMatchingStateNetworkErrorCount.current++;
+          if(checkMatchingStateNetworkErrorCount.current >= MAXIMUM_CHECK_MATCHING_STATE_NETWORK_ERROR_COUNT) {
+            cancelMatching(false);
+            console.log("matching cancelled due to network error");
+            navigate(`../matching/failed?message=Network error, please check your network and try again.&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+          }
+        }
+        else {
+          cancelMatching();
+          console.log("matching cancelled due to backend error");
+          navigate(`../matching/failed?message=${response.message}&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+        }
+      }
+    );
+  }
+
+  const cancelMatching = (sendCancellationRequest : boolean = true) => {
+    console.log("cancel matching");
+    if(checkMatchingStateIntervalID.current !== null) {
+      window.clearInterval(checkMatchingStateIntervalID.current);
+    }
+    if(endMatchingTimerIntervalID.current !== null) {
+      window.clearInterval(endMatchingTimerIntervalID.current);
+    }
+    if(sendCancellationRequest) {
+      sendCancelMatchingRequest(auth.token);
+    }
+    navigate("../matching/start");
+  }
+
+  const updateEndMatchingTimer = () => {
+    setEndMatchingTimer(val => {
+      if(val - 1 <= 0) {
+        cancelMatching();
+        console.log("matching cancelled due to timed out");
+        navigate(`../matching/failed?message=A match couldn't be found after ${MAXIMUM_MATCHING_DURATION} seconds. You may try again or refine your question selections to increase your chances to match.&difficulties=${difficultiesStr}&topics=${topicsStr}`);
+      }
+      return val - 1;
+    });
+    
+  }
+
+  useEffect(() => {
+    if(checkMatchingStateIntervalID.current === null) {
+      checkMatchingStateIntervalID.current = window.setInterval(checkMatchingState, CHECK_MATCHING_STATE_INTERVAL);
+    }
+    if(endMatchingTimerIntervalID.current === null) {
+      endMatchingTimerIntervalID.current = window.setInterval(updateEndMatchingTimer, 1000);
+    }
+  }, []);
+
+  document.title = "Matching | PeerPrep";
+
+  return (
+  <>
+    <PageHeader />
+    <MainContainer>
+      <div className="flex flex-col space-y-5 justify-center items-center">
+        <PageTitle>Please wait for a moment...</PageTitle>
+        {peerNotReady === "true" && (
+          <div className="text-red-500">Because the other user you've just matched with didn't get ready in time, now we are retry matching for you.</div>
+        )}
+        <div>Searching for students who also want to do <b>{difficultiesStr}</b> questions with topics <b>{topicsStr}</b>.</div>
+        <div>
+          <div className="h-10" />
+          <SpinningCircle>
+            <div className="text-2xl">{endMatchingTimer}</div>
+          </SpinningCircle>
+          <div className="h-10" />
+        </div>
+        <div className="flex justify-center mt-20">
+          <Button className="bg-red-500 text-white hover:bg-gray-500" onClick={()=>cancelMatching(true)}>Cancel matching</Button>
+        </div>
+      </div>
+    </MainContainer>
+  </>
+  )
+}

--- a/matching-service/src/model/MatchingQueue.ts
+++ b/matching-service/src/model/MatchingQueue.ts
@@ -9,11 +9,17 @@ TODO: matching based on user's requirements.
 export type TDifficulty = "easy" | "medium" | "hard";
 export type SelectedDifficultyData = {[difficulty in TDifficulty] : boolean};
 
+enum UserReadyState {
+    Waiting, // Waiting for the user to get ready
+    Ready, // The user has comfirmed that he or she is ready
+    NotReady, // The user failed to get ready in time
+}
+
 type User = {
     userToken : string,
     difficulties : SelectedDifficultyData,
     topics : string[]
-    isReady : boolean,
+    readyState : UserReadyState,
     matchedUser : User | null
 }
 
@@ -67,4 +73,4 @@ class MatchingQueue {
     }
 }
 
-export { MatchingQueue, User };
+export { MatchingQueue, UserReadyState, User };

--- a/matching-service/src/routes/MatchingRoute.ts
+++ b/matching-service/src/routes/MatchingRoute.ts
@@ -1,15 +1,38 @@
 import { Router, Request, Response } from "express";
-import { User } from "../model/MatchingQueue";
+import { User, UserReadyState } from "../model/MatchingQueue";
 import matchingManagerInstance from "../model/MatchingManager";
-
 
 const router = Router();
 
+/**
+ * API for the frontend to start matching for a user.
+ * 
+ * Request body:
+ * A JSON format contains the user's token, the selected difficulties and the topics.
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here",
+ *     "difficulties": {
+ *         "easy": true,
+ *         "medium": true,
+ *         "hard": false
+ *     },
+ *     "topics": ["DP", "Sorting"]
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the start matching request is successful, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON of either `matching started` for a successful request or an error message when there is an error.
+ * `{"message": "matching started"}`
+ */
 router.post("/start", async (req : Request, rsp : Response) => {
     const data = req.body;
     const user : User = {
         ...data,
-        isReady: false,
+        readyState: UserReadyState.Waiting,
         matchedUser: null
     }
     try {
@@ -21,6 +44,28 @@ router.post("/start", async (req : Request, rsp : Response) => {
     return rsp.status(200).send({message: "matching started"});
 });
 
+/**
+ * API for the frontend to check the matching state for a user.
+ * This API will be requested by the frontend intermittently over certain intervals when the frontend is waiting for a match
+ * 
+ * Request body:
+ * A JSON format contains the user's token
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here"
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the user's current matching status is still matching or have found a match, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON like:
+ * `{"message": "matching"}`
+ *  - If the user is still matching, the message should be `matching` and the frontend will continue waiting
+ *  - If the user is matched to another user, the message should be `match found` and the frontend will automatically navigate to the "Get Ready" page
+ *  - If any error happens, the message should be an error message, and the frontend will cancel waiting and automatically navigate to the "Matching Failed" page with the error massage
+ */
 router.post("/check_state", async (req : Request, rsp : Response) => {
     try {
         const { userToken } = req.body;
@@ -41,6 +86,29 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
     }
 });
 
+/**
+ * API for the frontend to notify the backend that a matching is cancelled.
+ * The cancellation may happen when:
+ *   - the user clicks the `Cancel matching` button
+ *   - the user navigates away from the waiting page
+ *   - the user navigates to the "Matching Failed" page after failed to get ready on time and after requesting `/ready_no`
+ *   - a backend error happens and the frontend stops waiting for matching or waiting for the other user to get ready
+ * 
+ * Request body:
+ * A JSON format contains the user's token
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here",
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the cancel matching request is successful, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON of either `success` for a successful request or an error message when there is an error.
+ * `{"message": "success"}`
+ */
 router.post("/cancel", async (req : Request, rsp : Response) => {
     try {
         const { userToken } = req.body;
@@ -51,5 +119,114 @@ router.post("/cancel", async (req : Request, rsp : Response) => {
         return rsp.status(500).send({message : error.message});
     }
 });
+
+/**
+ * API for the frontend to notify the backend when a user is ready
+ * 
+ * Request body:
+ * A JSON format contains the user's token
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here",
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the get ready request is successful, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON of either `success` for a successful request or an error message when there is an error.
+ * `{"message": "success"}`
+ */
+router.post("/ready/yes" , async (req : Request, rsp : Response) => {
+    try {
+        const { userToken } = req.body;
+        if(!matchingManagerInstance.isUserInMatchingService(userToken)) {
+            return rsp.status(400).send({message: "This user does not exist in the matching service."});
+        }
+        matchingManagerInstance.setReadyState(userToken, UserReadyState.Ready);
+        return rsp.status(200).send({message: "success"});
+    }
+    catch(error : any) {
+        return rsp.status(500).send({message : error.message});
+    }
+});
+
+/**
+ * API for the frontend to notify the backend that a a user failed to get ready in time (after the countdown timer expires)
+ *  
+ * Request body:
+ * A JSON format contains the user's token
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here",
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the cancel matching request is successful, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON of either "success" for a successful request or an error message when there is an error.
+ * `{"message": "success"}`
+ */
+router.post("/ready/no" , async (req : Request, rsp : Response) => {
+    try {
+        const { userToken } = req.body;
+        if(!matchingManagerInstance.isUserInMatchingService(userToken)) {
+            return rsp.status(400).send({message: "This user does not exist in the matching service."});
+        }
+        matchingManagerInstance.setReadyState(userToken, UserReadyState.NotReady);
+        return rsp.status(200).send({message: "success"});
+    }
+    catch(error : any) {
+        return rsp.status(500).send({message : error.message});
+    }
+});
+
+/**
+ * API for the frontend to check whether the other user in the match is ready or not
+ * This API will be requested by the frontend intermittently over certain intervals when the frontend is waiting for the other user to get ready
+ *  
+ * Request body:
+ * A JSON format contains the user's token
+ * Example request body:
+ * ```
+ * {
+ *     "userToken": "user-token-here",
+ * }
+ * ```
+ * 
+ * Response status:
+ * `200` if the check ready state request is successful, and other error status code when there is an error when processing the request.
+ * Response body:
+ * A message in JSON:
+ *  - If the other user is not ready and is still waiting for he/she to get ready, the message should be `waiting` and the frontend will continue waiting
+ *  - If the other user is ready, the message should be `ready` and the frontend will automatically navigate to the "Collaboration" page
+ *  - If the other user failed to get ready in time (after the get ready timer expires), the message should be `not ready` and the frontend will automatically retry matching.
+ *  - If any error happens, the message should be an error message, and the frontend will cancel waiting and automatically navigate to the "Matching Failed" page with the error massage
+ * `{"message": "success"}`
+ */
+router.post("/ready/check_state" , async (req : Request, rsp : Response) => {
+    const MESSAGE_READY = "ready";
+    const MESSAGE_NOT_READY = "not ready";
+    const MESSAGE_WAITING = "waiting";
+    try {
+        const { userToken } = req.body;
+        if(!matchingManagerInstance.isUserInMatchingService(userToken)) {
+            return rsp.status(400).send({message: "This user does not exist in the matching service."});
+        }
+        const peerReadyState = matchingManagerInstance.getPeerReadyState(userToken);
+        if(peerReadyState === UserReadyState.NotReady) {
+            matchingManagerInstance.dismissMatchedUsersAfterNotGettingReady(userToken);
+        }
+        const message = peerReadyState === UserReadyState.Ready ? MESSAGE_READY : peerReadyState === UserReadyState.NotReady ? MESSAGE_NOT_READY : MESSAGE_WAITING;
+        return rsp.status(200).send({message: message});
+    }
+    catch(error : any) {
+        return rsp.status(500).send({message : error.message});
+    }
+});
+
 
 export default router;


### PR DESCRIPTION
Revert every change made after my primitive matching service. Since our new matching service implementation based on Kafka is not working, please consider to use my primitive one as a backup plan for a matching service that can work for Milestone D4. (Now my primitive matching service will match every two users together without caring the users' requirements. Will implement this algorithm after you decide to use my primitive matching service instead of the Kafka one)