### PR TITLE
Matching Service: Match users by ID instead of token & Reinstate cancel button

### DIFF
--- a/frontend/src/api/matching-service/MatchingService.ts
+++ b/frontend/src/api/matching-service/MatchingService.ts
@@ -18,7 +18,7 @@ let previousStartMatchingData : any = null;
 /**
  * An async function for sending a start matching request to the backend.
  * 
- * @param id The current user's token.
+ * @param id The current user's id.
  * @param difficulties The difficulties selected by the user for matching.
  * @param topics The topics selected by the user for matching.
  * @returns An object containing the HTTP status code of the request and the message from the backend server
@@ -62,7 +62,7 @@ async function retryPreviousMatching(token : string) {
  * An async function for sending a check matching state request to the backend.
  * You should call this function intermittently for multiple times when waiting for matching in order to get the latest matching state.
  * 
- * @param email The current user's token.
+ * @param id The current user's id.
  * @returns An object containing the HTTP status code of the request and the message from the backend server.
  */
 async function sendCheckMatchingStateRequest(id : string) {

--- a/frontend/src/api/matching-service/MatchingService.ts
+++ b/frontend/src/api/matching-service/MatchingService.ts
@@ -23,9 +23,10 @@ let previousStartMatchingData : any = null;
  * @param topics The topics selected by the user for matching.
  * @returns An object containing the HTTP status code of the request and the message from the backend server
  */
-async function sendStartMatchingRequest(id : string, difficulties : SelectedDifficultyData, topics : string[]) {
+async function sendStartMatchingRequest(id : string, email : string, difficulties : SelectedDifficultyData, topics : string[]) {
   const requestBody = {
     id : id,
+    email : email,
     difficulties : difficulties,
     topics : topics
   }
@@ -86,9 +87,9 @@ async function sendCheckMatchingStateRequest(id : string) {
  * @param token The current user's token.
  * @returns An object containing the HTTP status code of the request and the message from the backend server.
  */
-async function sendCancelMatchingRequest(token : string) {
+async function sendCancelMatchingRequest(id : string) {
   const requestBody = {
-    userToken : token
+    id : id
   }
   return await api.post(MATCHING_BASE_URL + CANCEL_MATCHING_URL, requestBody).then(response => {
     return {status : response.status, message : response.data.message}

--- a/frontend/src/api/matching-service/MatchingService.ts
+++ b/frontend/src/api/matching-service/MatchingService.ts
@@ -18,14 +18,14 @@ let previousStartMatchingData : any = null;
 /**
  * An async function for sending a start matching request to the backend.
  * 
- * @param email The current user's token.
+ * @param id The current user's token.
  * @param difficulties The difficulties selected by the user for matching.
  * @param topics The topics selected by the user for matching.
  * @returns An object containing the HTTP status code of the request and the message from the backend server
  */
-async function sendStartMatchingRequest(email : string, difficulties : SelectedDifficultyData, topics : string[]) {
+async function sendStartMatchingRequest(id : string, difficulties : SelectedDifficultyData, topics : string[]) {
   const requestBody = {
-    email : email,
+    id : id,
     difficulties : difficulties,
     topics : topics
   }
@@ -65,9 +65,9 @@ async function retryPreviousMatching(token : string) {
  * @param email The current user's token.
  * @returns An object containing the HTTP status code of the request and the message from the backend server.
  */
-async function sendCheckMatchingStateRequest(email : string) {
+async function sendCheckMatchingStateRequest(id : string) {
   const requestBody = {
-    email : email
+    id : id
   }
   return await api.post(MATCHING_BASE_URL + CHECK_MATCHING_STATE_URL, requestBody).then(response => {
     return {status : response.status, message : response.data.message}

--- a/frontend/src/api/matching-service/MatchingService.ts
+++ b/frontend/src/api/matching-service/MatchingService.ts
@@ -18,14 +18,14 @@ let previousStartMatchingData : any = null;
 /**
  * An async function for sending a start matching request to the backend.
  * 
- * @param token The current user's token.
+ * @param email The current user's token.
  * @param difficulties The difficulties selected by the user for matching.
  * @param topics The topics selected by the user for matching.
  * @returns An object containing the HTTP status code of the request and the message from the backend server
  */
-async function sendStartMatchingRequest(token : string, difficulties : SelectedDifficultyData, topics : string[]) {
+async function sendStartMatchingRequest(email : string, difficulties : SelectedDifficultyData, topics : string[]) {
   const requestBody = {
-    userToken : token,
+    email : email,
     difficulties : difficulties,
     topics : topics
   }
@@ -62,12 +62,12 @@ async function retryPreviousMatching(token : string) {
  * An async function for sending a check matching state request to the backend.
  * You should call this function intermittently for multiple times when waiting for matching in order to get the latest matching state.
  * 
- * @param token The current user's token.
+ * @param email The current user's token.
  * @returns An object containing the HTTP status code of the request and the message from the backend server.
  */
-async function sendCheckMatchingStateRequest(token : string) {
+async function sendCheckMatchingStateRequest(email : string) {
   const requestBody = {
-    userToken : token
+    email : email
   }
   return await api.post(MATCHING_BASE_URL + CHECK_MATCHING_STATE_URL, requestBody).then(response => {
     return {status : response.status, message : response.data.message}

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -37,7 +37,7 @@ export default function StartMatchingForm() {
     const topicsStr = questionTopics.join(", ");
     navigate(`../matching/wait?difficulties=${difficultiesStr}&topics=${topicsStr}`);
 
-    sendStartMatchingRequest(auth.id, selectedDifficultyData, questionTopics).then(
+    sendStartMatchingRequest(auth.id, auth.email, selectedDifficultyData, questionTopics).then(
       response => {
         const httpStatus = response.status;
         const errorMessage = response.message

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -37,7 +37,7 @@ export default function StartMatchingForm() {
     const topicsStr = questionTopics.join(", ");
     navigate(`../matching/wait?difficulties=${difficultiesStr}&topics=${topicsStr}`);
 
-    sendStartMatchingRequest(auth.email, selectedDifficultyData, questionTopics).then(
+    sendStartMatchingRequest(auth.id, selectedDifficultyData, questionTopics).then(
       response => {
         const httpStatus = response.status;
         const errorMessage = response.message

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -11,6 +11,7 @@ import { DisplayedMessage, DisplayedMessageContainer, DisplayedMessageTypes } fr
 const HTTP_OK = 200
 const HTTP_NO_CONTENT = 204
 const HTTP_REQUEST_TIMEOUT = 408
+const HTTP_ALREADY_EXISTS = 409
 
 export default function StartMatchingForm() {
 
@@ -44,7 +45,7 @@ export default function StartMatchingForm() {
 
         if (httpStatus === HTTP_OK) {
           // navigate("/matching/get_ready")
-        } else if (httpStatus === HTTP_NO_CONTENT || httpStatus === HTTP_REQUEST_TIMEOUT) {
+        } else if (httpStatus === HTTP_NO_CONTENT || httpStatus === HTTP_REQUEST_TIMEOUT || httpStatus === HTTP_ALREADY_EXISTS) {
           navigate(`/matching/failed?message=${errorMessage}&difficulties=${difficultiesStr}&topics=${topicsStr}`);
         } else {
           displayError("An error has occured: \n" + response.message);

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -9,9 +9,8 @@ import { useNavigate } from "react-router-dom";
 import { DisplayedMessage, DisplayedMessageContainer, DisplayedMessageTypes } from "../common/DisplayedMessage";
 
 const HTTP_OK = 200
-const HTTP_NO_CONTENT = 204
-const HTTP_REQUEST_TIMEOUT = 408
 const HTTP_ALREADY_EXISTS = 409
+const HTTP_ERROR = 500
 
 export default function StartMatchingForm() {
 
@@ -44,8 +43,8 @@ export default function StartMatchingForm() {
         const errorMessage = response.message
 
         if (httpStatus === HTTP_OK) {
-          // navigate("/matching/get_ready")
-        } else if (httpStatus === HTTP_NO_CONTENT || httpStatus === HTTP_REQUEST_TIMEOUT || httpStatus === HTTP_ALREADY_EXISTS) {
+          // Do nothing here
+        } else if (httpStatus === HTTP_ALREADY_EXISTS || httpStatus === HTTP_ERROR) {
           navigate(`/matching/failed?message=${errorMessage}&difficulties=${difficultiesStr}&topics=${topicsStr}`);
         } else {
           displayError("An error has occured: \n" + response.message);

--- a/frontend/src/components/matching-service/StartMatchingForm.tsx
+++ b/frontend/src/components/matching-service/StartMatchingForm.tsx
@@ -37,7 +37,7 @@ export default function StartMatchingForm() {
     const topicsStr = questionTopics.join(", ");
     navigate(`../matching/wait?difficulties=${difficultiesStr}&topics=${topicsStr}`);
 
-    sendStartMatchingRequest(auth.token, selectedDifficultyData, questionTopics).then(
+    sendStartMatchingRequest(auth.email, selectedDifficultyData, questionTopics).then(
       response => {
         const httpStatus = response.status;
         const errorMessage = response.message

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -114,7 +114,7 @@ export default function WaitForMatchingPage() {
   const updateEndMatchingTimer = () => {
     setEndMatchingTimer(val => {
       if(val - 1 <= 0) {
-        cancelMatching();
+        cancelMatching(false);
         console.log("matching cancelled due to timed out");
         navigate(`../matching/failed?message=A match couldn't be found after ${MAXIMUM_MATCHING_DURATION} seconds. You may try again or refine your question selections to increase your chances to match.&difficulties=${difficultiesStr}&topics=${topicsStr}`);
       }

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -93,7 +93,7 @@ export default function WaitForMatchingPage() {
       window.clearInterval(endMatchingTimerIntervalID.current);
     }
     if(sendCancellationRequest) {
-      sendCancelMatchingRequest(auth.token);
+      sendCancelMatchingRequest(auth.id);
     }
     navigate("../matching/start");
   }

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -50,7 +50,7 @@ export default function WaitForMatchingPage() {
       console.log("matching cancelled due to leaving page");
       return;
     }
-    sendCheckMatchingStateRequest(auth.token).then(
+    sendCheckMatchingStateRequest(auth.email).then(
       response => {
         const isSuccess = response.status === 200;
         if(isSuccess) {

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -52,16 +52,15 @@ export default function WaitForMatchingPage() {
     }
     sendCheckMatchingStateRequest(auth.id).then(
       response => {
-        const isSuccess = response.status === 200;
-        if(isSuccess) {
-          if(response.message === "match found") {
-            console.log("match found!");
-            cancelMatching(false);
-            navigate(`../collaboration`);
-          }
-          return;
+        if(response.status === 200) {
+          console.log("match found!");
+          cancelMatching(false);
+          navigate(`../collaboration`);
+        } else if (response.status === 202) {
+          //Do nothing
+          console.log("matching...");
         }
-        if(response.message === "ERR_NETWORK") {
+        else if (response.message === "ERR_NETWORK") {
           checkMatchingStateNetworkErrorCount.current++;
           if(checkMatchingStateNetworkErrorCount.current >= MAXIMUM_CHECK_MATCHING_STATE_NETWORK_ERROR_COUNT) {
             cancelMatching(false);

--- a/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
+++ b/frontend/src/pages/matching-service/WaitForMatchingPage.tsx
@@ -50,7 +50,7 @@ export default function WaitForMatchingPage() {
       console.log("matching cancelled due to leaving page");
       return;
     }
-    sendCheckMatchingStateRequest(auth.email).then(
+    sendCheckMatchingStateRequest(auth.id).then(
       response => {
         const isSuccess = response.status === 200;
         if(isSuccess) {

--- a/matching-service/src/controllers/matchingController.ts
+++ b/matching-service/src/controllers/matchingController.ts
@@ -73,8 +73,9 @@ export const startMatching = async () => {
                 if (waitingQueue.isUserInQueue(key)) {
                     const user = userStore.getUser(key)!;
                     waitingQueue.removeUser(user);
+                    userStore.removeUser(key);
                     // User email cannot be logged here as the user object is removed from the store
-                    console.log(`User ${key} has been removed from the queue.`);
+                    console.log(`User ${user.email} has been removed from the queue.`);
                     console.log("Queue status: ", waitingQueue.getUserEmails());
                 }
                 return;
@@ -94,10 +95,9 @@ export const startMatching = async () => {
                 if (newUser.matchedUser === null) {
                     console.log(`User ${newUser.email} has timed out and will be removed from the queue.`);
                     waitingQueue.removeUser(newUser); // Remove user from the queue
+                    userStore.removeUser(newUser.id); // Remove user from the store
                     console.log("Queue status: ", waitingQueue.getUserEmails());
 
-                    // Send message to notify user that no match was found
-                    // sendMatchResult(newUser.userToken, 'timeout');
                 }
             }, TIMEOUT_DURATION);
 
@@ -304,9 +304,9 @@ const producer = kafka.producer();
 export const sendQueueingMessage = async (id: string, isCancel: boolean = false) => {
     await producer.connect();
     if (isCancel) {
-        console.log(`Sending user ${id} to the queue to cancel.`);
+        console.log(`Sending User ${id} to the queue to cancel.`);
     } else {
-        console.log(`Sending user ${id} to the queue.`);
+        console.log(`Sending User ${id} to the queue.`);
     }
     await producer.send({
         topic: 'user-matching',

--- a/matching-service/src/controllers/matchingController.ts
+++ b/matching-service/src/controllers/matchingController.ts
@@ -33,7 +33,7 @@ const findMatchingUser = (newUser: User, waitingQueue: Queue): User | null => {
         const user = waitingQueue.peek(i);
 
         // Avoid matching with itself
-        if (newUser.userToken === user.userToken) {
+        if (newUser.email === user.email) {
             continue;
         }
 
@@ -79,11 +79,11 @@ export const startMatching = async () => {
                 return;
             }
 
-            console.log(`User ${newUser.userToken} is ready to be matched.`);
+            console.log(`User ${newUser.email} is ready to be matched.`);
 
             const timeout = setTimeout(() => {
                 if (newUser.matchedUser === null) {
-                    console.log(`User ${newUser.userToken} has timed out and will be removed from the queue.`);
+                    console.log(`User ${newUser.email} has timed out and will be removed from the queue.`);
                     waitingQueue.removeUser(newUser); // Remove user from the queue
 
                     // Send message to notify user that no match was found
@@ -102,7 +102,7 @@ export const startMatching = async () => {
 
 
             if (matchedUser) {
-                console.log(`Matched user ${matchedUser.userToken} with ${newUser.userToken}`);
+                console.log(`Matched user ${matchedUser.email} with ${newUser.email}`);
 
                 // Update matched user fields
                 matchedUser.matchedUser = newUser;
@@ -114,6 +114,7 @@ export const startMatching = async () => {
                     clearTimeout(matchedUser.timeout);
                 }
 
+                /*
                 // Add new timeout for confirmation
                 const confirmationTimeout = setTimeout(() => {
                     if (!newUser.isPeerReady || !matchedUser.isPeerReady) {
@@ -132,6 +133,7 @@ export const startMatching = async () => {
                 // Update timeout for both users
                 newUser.timeout = confirmationTimeout;
                 matchedUser.timeout = confirmationTimeout;
+                */
 
                 // Remove matched user from the queue
                 waitingQueue.removeUser(matchedUser); 
@@ -145,7 +147,7 @@ export const startMatching = async () => {
                 // Add user to the waiting queue
                 waitingQueue.push(newUser);
                 console.log("Queue status: ", waitingQueue);
-                console.log(`User ${newUser.userToken} added to waiting list`);
+                console.log(`User ${newUser.email} added to waiting list`);
             }
         }
     });
@@ -291,13 +293,13 @@ const producer = kafka.producer();
  * @param user Topics, difficulties, and user token
  * @param isCancel Whether the user wants to stop matching, set to false by default
  */
-export const sendQueueingMessage = async (userToken: string, isCancel: boolean = false) => {
+export const sendQueueingMessage = async (email: string, isCancel: boolean = false) => {
     await producer.connect();
-    console.log(`Sending user ${userToken} to the queue.`);
+    console.log(`Sending user ${email} to the queue.`);
     await producer.send({
         topic: 'user-matching',
         messages: [
-            { key: userToken, value: isCancel ? null : userToken },
+            { key: email, value: isCancel ? null : email },
         ],
     });
     await producer.disconnect();

--- a/matching-service/src/controllers/matchingController.ts
+++ b/matching-service/src/controllers/matchingController.ts
@@ -58,7 +58,7 @@ export const startMatching = async () => {
     await consumer.connect();
     await consumer.subscribe({ topic: "user-matching", fromBeginning: true });
     const waitingQueue = new Queue();
-    console.log("Queue status: ", waitingQueue);
+    console.log("Queue status: ", waitingQueue.getUserTokens());
 
     await consumer.run({
         eachMessage: async ({ message } : { message : any }) => {
@@ -85,6 +85,7 @@ export const startMatching = async () => {
                 if (newUser.matchedUser === null) {
                     console.log(`User ${newUser.email} has timed out and will be removed from the queue.`);
                     waitingQueue.removeUser(newUser); // Remove user from the queue
+                    console.log("Queue status: ", waitingQueue.getUserTokens());
 
                     // Send message to notify user that no match was found
                     // sendMatchResult(newUser.userToken, 'timeout');
@@ -97,9 +98,6 @@ export const startMatching = async () => {
             // Search for a matching user in the queue, starting from the oldest user
             // TODO: specify type of queue used
             const matchedUser = findMatchingUser(newUser, waitingQueue); 
-
-            console.log(`Found matching user: ${matchedUser}`);
-
 
             if (matchedUser) {
                 console.log(`Matched user ${matchedUser.email} with ${newUser.email}`);
@@ -137,7 +135,8 @@ export const startMatching = async () => {
 
                 // Remove matched user from the queue
                 waitingQueue.removeUser(matchedUser); 
-                console.log("Queue status: ", waitingQueue);
+                console.log("Remove matched user from queue: User ", matchedUser.email);
+                console.log("Queue status: ", waitingQueue.getUserTokens());
 
 
                 // Notify both users that a match has been found
@@ -146,8 +145,8 @@ export const startMatching = async () => {
             } else { 
                 // Add user to the waiting queue
                 waitingQueue.push(newUser);
-                console.log("Queue status: ", waitingQueue);
                 console.log(`User ${newUser.email} added to waiting list`);
+                console.log("Queue status: ", waitingQueue.getUserTokens());
             }
         }
     });

--- a/matching-service/src/controllers/matchingController.ts
+++ b/matching-service/src/controllers/matchingController.ts
@@ -72,6 +72,7 @@ export const startMatching = async () => {
                 //Remove user from waiting queue if inside
                 if (waitingQueue.isUserInQueue(key)) {
                     const user = userStore.getUser(key)!;
+                    clearTimeout(user.timeout!);
                     waitingQueue.removeUser(user);
                     userStore.removeUser(key);
                     // User email cannot be logged here as the user object is removed from the store

--- a/matching-service/src/model/queue.ts
+++ b/matching-service/src/model/queue.ts
@@ -65,6 +65,15 @@ class Queue {
  
         return user_ids;  
     }
+
+    getUserEmails() : string[] { 
+        const user_emails: string[] = []; 
+        this.queue.forEach((user) => { 
+            user_emails.push(user.email);  
+        }); 
+ 
+        return user_emails;  
+    }
 }
 
 export { Queue };

--- a/matching-service/src/model/queue.ts
+++ b/matching-service/src/model/queue.ts
@@ -21,7 +21,7 @@ class Queue {
     }
 
     push(user : User) : void {
-        if(this.isUserInQueue(user.email)) {
+        if(this.isUserInQueue(user.id)) {
             throw new Error("This user is already matching.");
         }
         this.queue.push(user);
@@ -49,21 +49,21 @@ class Queue {
         return this.count() === 0;
     }
 
-    isUserInQueue(email : string) : boolean {
-        return this.queue.filter(u => u.email === email).length > 0;
+    isUserInQueue(id : string) : boolean {
+        return this.queue.filter(u => u.id === id).length > 0;
     }
 
     removeUser(user : User) : void {
         this.removeAt(this.queue.indexOf(user));
     }
 
-    getUserTokens() : string[] { 
-        const user_emails: string[] = []; 
+    getUserIds() : string[] { 
+        const user_ids: string[] = []; 
         this.queue.forEach((user) => { 
-            user_emails.push(user.email);  
+            user_ids.push(user.id);  
         }); 
  
-        return user_emails;  
+        return user_ids;  
     }
 }
 

--- a/matching-service/src/model/queue.ts
+++ b/matching-service/src/model/queue.ts
@@ -21,7 +21,7 @@ class Queue {
     }
 
     push(user : User) : void {
-        if(this.isUserInQueue(user.userToken)) {
+        if(this.isUserInQueue(user.email)) {
             throw new Error("This user is already matching.");
         }
         this.queue.push(user);
@@ -49,8 +49,8 @@ class Queue {
         return this.count() === 0;
     }
 
-    isUserInQueue(userToken : string) : boolean {
-        return this.queue.filter(u => u.userToken === userToken).length > 0;
+    isUserInQueue(email : string) : boolean {
+        return this.queue.filter(u => u.email === email).length > 0;
     }
 
     removeUser(user : User) : void {
@@ -58,12 +58,12 @@ class Queue {
     }
 
     getUserTokens() : string[] { 
-        const user_tokens: string[] = []; 
+        const user_emails: string[] = []; 
         this.queue.forEach((user) => { 
-            user_tokens.push(user.userToken);  
+            user_emails.push(user.email);  
         }); 
  
-        return user_tokens;  
+        return user_emails;  
     }
 }
 

--- a/matching-service/src/model/user.ts
+++ b/matching-service/src/model/user.ts
@@ -2,7 +2,7 @@ export type TDifficulty = "easy" | "medium" | "hard";
 export type SelectedDifficultyData = {[difficulty in TDifficulty] : boolean};
 
 interface User {
-    userToken : string;
+    email : string;
     difficulties : SelectedDifficultyData;
     topics : string[];
     timeout : NodeJS.Timeout | null;

--- a/matching-service/src/model/user.ts
+++ b/matching-service/src/model/user.ts
@@ -2,6 +2,7 @@ export type TDifficulty = "easy" | "medium" | "hard";
 export type SelectedDifficultyData = {[difficulty in TDifficulty] : boolean};
 
 interface User {
+    id : string;
     email : string;
     difficulties : SelectedDifficultyData;
     topics : string[];

--- a/matching-service/src/routes/routes.ts
+++ b/matching-service/src/routes/routes.ts
@@ -56,7 +56,7 @@ router.post("/start_matching", async (req : Request, res : Response) => {
         //         return res.status(408).send({message: "No match found due to timeout"});
         //     }
         // });
-        return res.status(200).send({message: "Started Queueing"});
+        return res.status(200).send({message: "Started Queueing User: " + user.email});
 
         // By default, no match is found
         // userStore.removeUser(user.userToken);
@@ -93,7 +93,7 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
 
             const user = userStore.getUser(id);
             if(user!.matchedUser) {
-                console.log('Status: Match found for user:', id);
+                console.log('Status: Match found for user:', user?.email);
                 return rsp.status(200).send({message: "match found"});
             } else {
                 return rsp.status(200).send({message: "matching"});
@@ -171,24 +171,24 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
 //  * - 400: User not found
 //  * - 500: Error cancelling matching
 //  */
-// router.post("/cancel", async (req : Request, res : Response) => {
-//     try {
-//         const userId = req.body.id;
-//         const user = userStore.getUser(userId);
+router.post("/cancel", async (req : Request, res : Response) => {
+    try {
+        const userId = req.body.id;
+        const user = userStore.getUser(userId);
         
-//         if (user) {
-//             // Send tombstone message to the Kafka topic to remove user from the queue
-//             await sendQueueingMessage(userId, true);
-//         } else {
-//             return res.status(400).send({ message: "User not found" });
-//         }
+        if (user) {
+            // Send tombstone message to the Kafka topic to remove user from the queue
+            await sendQueueingMessage(userId, true);
+        } else {
+            return res.status(400).send({ message: "User not found" });
+        }
 
-//         userStore.removeUser(userId);
-//         return res.status(200).send({message: "User is removed from queue"});
-//     }
-//     catch(error : any) {
-//         return res.status(500).send({message : error.message});
-//     }
-// });
+        userStore.removeUser(userId);
+        return res.status(200).send({message: "User is removed from queue"});
+    }
+    catch(error : any) {
+        return res.status(500).send({message : error.message});
+    }
+});
 
 export default router;

--- a/matching-service/src/routes/routes.ts
+++ b/matching-service/src/routes/routes.ts
@@ -9,11 +9,11 @@ const router = Router();
  * Start the matching process for the user. 
  * 
  * Request body should contain the following fields:
- * A JSON format contains the user's token, the selected difficulties and the topics.
+ * A JSON format contains the user's id, the selected difficulties and the topics.
  * Example request body:
  * ```
  * {
- *     "userToken": "user-token-here",
+ *     "id": "id",
  *     "difficulties": {
  *         "easy": true,
  *         "medium": true,
@@ -69,6 +69,18 @@ router.post("/start_matching", async (req : Request, res : Response) => {
     }
 });
 
+/**
+ * Check the matching state for the user
+ * 
+ * Request body should contain the user's id.
+ * 
+ * Response status:
+ * - 200: Match found
+ * - 204: Matching
+ * - 400: User ID not found
+ * - 400: User not found in the queue
+ * - 500: Error checking match status
+ */
 router.post("/check_state", async (req : Request, rsp : Response) => {
     try {
         const id = req.body.id;
@@ -161,17 +173,17 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
 //  */
 // router.post("/cancel", async (req : Request, res : Response) => {
 //     try {
-//         const { userToken } = req.cookies.jwt;
-//         const user = userStore.getUser(userToken);
+//         const userId = req.body.id;
+//         const user = userStore.getUser(userId);
         
 //         if (user) {
 //             // Send tombstone message to the Kafka topic to remove user from the queue
-//             await sendQueueingMessage(user.userToken, true);
-//             userStore.removeUser(userToken);
+//             await sendQueueingMessage(userId, true);
 //         } else {
 //             return res.status(400).send({ message: "User not found" });
 //         }
 
+//         userStore.removeUser(userId);
 //         return res.status(200).send({message: "User is removed from queue"});
 //     }
 //     catch(error : any) {

--- a/matching-service/src/routes/routes.ts
+++ b/matching-service/src/routes/routes.ts
@@ -53,9 +53,6 @@ router.post("/start_matching", async (req : Request, res : Response) => {
         
         return res.status(200).send({message: "Started Queueing User: " + user.email});
 
-        // By default, no match is found
-        // userStore.removeUser(user.userToken);
-        // return res.status(204).send({message: "No match found"});
     }
     catch(error) {
         console.error("Error when trying to match:" + error);
@@ -83,7 +80,7 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
             return rsp.status(400).send({message: "ID is not provided for checking status."});
         } else {
             if(!userStore.hasUser(id)) {
-                return rsp.status(400).send({message: "This user does not exist in the queue."});
+                return rsp.status(400).send({message: "This user does not exist in the queue anymore. Please try matching again."});
             }
 
             const user = userStore.getUser(id);
@@ -92,7 +89,7 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
                 console.log('Status: Match found for user:', user?.email);
                 return rsp.status(200).send({message: "match found"});
             } else {
-                return rsp.status(200).send({message: "matching"});
+                return rsp.status(202).send({message: "matching"});
             }
         }
 

--- a/matching-service/src/routes/routes.ts
+++ b/matching-service/src/routes/routes.ts
@@ -85,7 +85,6 @@ router.post("/check_state", async (req : Request, rsp : Response) => {
                 console.log('Status: Match found for user:', email);
                 return rsp.status(200).send({message: "match found"});
             } else {
-                console.log('Status: Matching for user:', email);
                 return rsp.status(200).send({message: "matching"});
             }
         }

--- a/matching-service/src/utils/userStore.ts
+++ b/matching-service/src/utils/userStore.ts
@@ -2,7 +2,7 @@ import { User } from "../model/user";
 
 
 // UserStore is a singleton class that stores all the users 
-// that are currently in the matching service to map them to their userToken.
+// that are currently in the matching service to map them to their user id.
 class UserStore {
     private userStore: Map<string, User>;
 
@@ -10,20 +10,20 @@ class UserStore {
         this.userStore = new Map<string, User>();
     }
 
-    addUser(userToken: string, userObject: User) {
-        this.userStore.set(userToken, userObject);
+    addUser(userId: string, userObject: User) {
+        this.userStore.set(userId, userObject);
     }
 
-    getUser(userToken: string) {
-        return this.userStore.get(userToken);
+    getUser(userId: string) {
+        return this.userStore.get(userId);
     }
 
-    removeUser(userToken: string) {
-        this.userStore.delete(userToken);
+    removeUser(userId: string) {
+        this.userStore.delete(userId);
     }
 
-    hasUser(userToken: string) {
-        return this.userStore.has(userToken);
+    hasUser(userId: string) {
+        return this.userStore.has(userId);
     }
 }
 

--- a/matching-service/src/utils/userStore.ts
+++ b/matching-service/src/utils/userStore.ts
@@ -25,6 +25,14 @@ class UserStore {
     hasUser(userId: string) {
         return this.userStore.has(userId);
     }
+
+    toString() {
+        let userStoreString = "";
+        this.userStore.forEach((user, userId) => {
+            userStoreString += userId + " : " + user.toString() + "\n";
+        });
+        return userStoreString;
+    }
 }
 
 const userStore = new UserStore();


### PR DESCRIPTION
Things I've done in this PR:
- Switch from matching based on user token to user id instead. To test the matching service, you'll need to use 2 different accounts now
- Updated console logs for the matching logic to make the status of each user and waiting queue clearer
- Reinstate the cancel button
- Handle error where users are trying to match from the same account in 2 windows

Logs:
![image](https://github.com/user-attachments/assets/d6f178b6-3ef6-4baa-858f-bf098cabd66d)

ignore the branch name 