### PR TITLE
Change the default theme of the code editor

### DIFF
--- a/frontend/src/components/collaboration-service/AceEditorThemes.ts
+++ b/frontend/src/components/collaboration-service/AceEditorThemes.ts
@@ -5,6 +5,10 @@ type AceEditorTheme = {
 
 const AceEditorThemes : AceEditorTheme[] = [
     {
+        displayName: "Cloud9 Night",
+        internalName: "cloud9_night",
+    },
+    {
         displayName: "GitHub",
         internalName: "github",
     },
@@ -13,13 +17,13 @@ const AceEditorThemes : AceEditorTheme[] = [
         internalName: "github_dark",
     },
     {
+        displayName: "Terminal",
+        internalName: "terminal",
+    },
+    {
         displayName: "Twilight",
         internalName: "twilight",
     },
-    {
-        displayName: "Terminal",
-        internalName: "terminal",
-    }
 ];
 
 export { AceEditorThemes };

--- a/frontend/src/components/collaboration-service/CodeEditingArea.tsx
+++ b/frontend/src/components/collaboration-service/CodeEditingArea.tsx
@@ -25,6 +25,7 @@ import "ace-builds/src-noconflict/mode-python";
 import "ace-builds/src-noconflict/mode-typescript";
 
 // Ace Editor Themes
+import "ace-builds/src-noconflict/theme-cloud9_night"
 import "ace-builds/src-noconflict/theme-github";
 import "ace-builds/src-noconflict/theme-github_dark";
 import "ace-builds/src-noconflict/theme-twilight";


### PR DESCRIPTION
Changed the default theme of the code editor to a dark theme with clear syntax highlighting

![image](https://github.com/user-attachments/assets/93f590ee-60f6-409d-afd0-a18ffb4155c2)

