### PR TITLE
Fix bug where user's attempted code is not reflected in ViewQuestionPage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,7 +153,7 @@ function App() {
               nonAdminRoute={ <Navigate to="/questions" /> }
             />
           } />
-          <Route path="/attempts/:id" element={
+          <Route path="/attempts/:id/:timeSubmitted" element={
             <PrivateRoute>
               <ViewQuestionPage hasCode={true}/>
             </PrivateRoute>

--- a/frontend/src/pages/AttemptedHistoryPage.tsx
+++ b/frontend/src/pages/AttemptedHistoryPage.tsx
@@ -39,7 +39,7 @@ export default function AttemptedHistoryPage() {
         const result = await getUserAttempts(auth.id);
         
         if (result.status === 200) {
-          setAttemptedQuestions(result.data);
+          setAttemptedQuestions(result.data.sort((a: Attempt, b: Attempt) => new Date(b.timeSubmitted).getTime() - new Date(a.timeSubmitted).getTime()));
           setError("");
           setTotalPages(Math.ceil(result.data.length / itemsPerPage));
         } else {

--- a/frontend/src/pages/AttemptedHistoryPage.tsx
+++ b/frontend/src/pages/AttemptedHistoryPage.tsx
@@ -18,8 +18,8 @@ export interface Attempt {
   code: string;
 }
 
-const DEFAULT_ITEMS_PER_PAGE = 5;
-const ITEMS_PER_PAGE_OPTIONS = [5, 10, 20];
+const DEFAULT_ITEMS_PER_PAGE = 10;
+const ITEMS_PER_PAGE_OPTIONS = [10, 20, 50];
 
 export default function AttemptedHistoryPage() {
   const [attemptedQuestions, setAttemptedQuestions] = useState<Attempt[]>([]);
@@ -88,7 +88,7 @@ export default function AttemptedHistoryPage() {
               <TableHeader className="bg-black-100">
                 <TableRow>
                   <TableHead>Question ID</TableHead>
-                  <TableHead>Time Submitted</TableHead>
+                  <TableHead>Time since attempt</TableHead>
                   <TableHead>Question</TableHead>
                   <TableHead>Language</TableHead>
                 </TableRow>
@@ -105,7 +105,7 @@ export default function AttemptedHistoryPage() {
                       </TableCell>
                       <TableCell className="px-4 py-1">
                         <Link
-                          to={`/attempts/${question.questionId}`}
+                          to={`/attempts/${question.questionId}/${question.timeSubmitted}`}
                           className="text-blue-500 hover:text-blue-700 hover:underline"
                         >
                           {question.questionTitle}

--- a/frontend/src/pages/question-service/ViewQuestionPage.tsx
+++ b/frontend/src/pages/question-service/ViewQuestionPage.tsx
@@ -27,6 +27,8 @@ interface CodeDisplay {
 export default function ViewQuestionPage({ hasCode = false } : ViewQuestionPageProps) {
   const params = useParams();
   const id = params.id as string;
+  console.log("params: ", params)
+  const timeSubmitted = new Date(params.timeSubmitted!);
   const { auth } = useAuth();
 
   const [question, setQuestion] = useState<Question | null>(null);
@@ -54,10 +56,15 @@ export default function ViewQuestionPage({ hasCode = false } : ViewQuestionPageP
       try {
         const result = await getUserAttempts(auth.id);
         console.log(result.data)
+        console.log(timeSubmitted)
         if (result.status === 200) {
           // Filter the attempts for the specific questionId
           const matchedAttempts = result.data
-            .filter((attempt: Attempt) => attempt.questionId === parseQuestionId(id))
+            .filter((attempt: Attempt) => {
+              console.log("time submitted;", attempt.timeSubmitted)
+              return (attempt.questionId === parseQuestionId(id)) && new Date(attempt.timeSubmitted).getTime() == new Date(timeSubmitted).getTime()
+              
+              })
             .sort((a: Attempt, b: Attempt) => new Date(b.timeSubmitted).getTime() - new Date(a.timeSubmitted).getTime());
 
           // Select the latest attempt (first one in sorted array)

--- a/frontend/src/pages/question-service/ViewQuestionPage.tsx
+++ b/frontend/src/pages/question-service/ViewQuestionPage.tsx
@@ -13,7 +13,6 @@ import { Attempt } from "../AttemptedHistoryPage";
 import { parseQuestionId } from "../../lib/utils"
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { darcula } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import Markdown from "react-markdown";
 import CustomMarkdown from "@/components/common/CustomMarkdown";
 
 interface ViewQuestionPageProps {
@@ -57,12 +56,17 @@ export default function ViewQuestionPage({ hasCode = false } : ViewQuestionPageP
         console.log(result.data)
         if (result.status === 200) {
           // Filter the attempts for the specific questionId
-          const matchedAttempt = result.data.find((attempt: Attempt) => attempt.questionId === parseQuestionId(id));
-          console.log("matchedAttempt: ", matchedAttempt)
-          if (matchedAttempt) {
+          const matchedAttempts = result.data
+            .filter((attempt: Attempt) => attempt.questionId === parseQuestionId(id))
+            .sort((a: Attempt, b: Attempt) => new Date(b.timeSubmitted).getTime() - new Date(a.timeSubmitted).getTime());
+
+          // Select the latest attempt (first one in sorted array)
+          const latestAttempt = matchedAttempts[0];
+          console.log("matchedAttempt: ", latestAttempt)
+          if (latestAttempt) {
             // If attempt found, set the code
-            console.log("stuff: ", { code: matchedAttempt.code, language: matchedAttempt.language })
-            setAttemptCode({ code: matchedAttempt.code, language: matchedAttempt.language });
+            console.log("stuff: ", { code: latestAttempt.code, language: latestAttempt.language })
+            setAttemptCode({ code: latestAttempt.code, language: latestAttempt.language });
           } else {
             // No matching attempt found for the question
             setAttemptCode(null);


### PR DESCRIPTION
What i did:

- Change the column name from 'time submitted' to 'time since attempt'
- Fix the bug where the same code is shown when the user is viewing question 72
- Change the default to 10 questions per page and the user can choose between 10, 20 and 50 now.
- When the same question is attempted multiple times, each of the question will show that particular attempt instead of showing the latest attempt.